### PR TITLE
Update to Python 3.13 and expand CI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.5.5
+      - image: cimg/python:3.13
 
     working_directory: ~/repo
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: ${{ matrix.python-version }}
       - uses: pre-commit/action@v3.0.1
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.13'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Simple and easy to use library for working with video equipment from Hikvision.
 
+Supports **Python 3.8** through **3.13**.
+
 ## Install
 
 ```bash


### PR DESCRIPTION
## Summary
- use Python 3.13 for packaging
- run CI against Python 3.8 through 3.13
- update CircleCI image to Python 3.13

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/workflows/publish-to-test-pypi.yml .circleci/config.yml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dc0b8140083309002ed3af91d6226